### PR TITLE
adds missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Installation
   * `gcc`: >= 4.9.2 tested on Debian 7.8 (wheezy)
   * `zlib`: v1.2.7 tested on Debian 7.8 (wheezy)
   * `gsl` : v1.15 tested on Debian 7.8 (wheezy)
+  * `libbz2.so`, required by **htslib**
+  * `liblzma.so`, required by **htslib**
+  * `libcurl.so`, required by **angsd**
 * Optional (only needed for testing or auxilliary scripts):
   * `md5sum`
   * `samtools`


### PR DESCRIPTION
Building with the current set of sub-modules is missing some dependencies. I've added these here. The versions I used were **bzip2 1.0.6**, **xz 5.0.4**, and **curl 7.41.0**.